### PR TITLE
Add --no-comp option

### DIFF
--- a/tree/rebol/Siskin/siskin.reb
+++ b/tree/rebol/Siskin/siskin.reb
@@ -85,6 +85,7 @@ all-options: [
 	  -  "--no-upx"  -      "Ignore default project's UPX compression setting"
 	  -  "--script"  "path" "Evaluate Rebol script"
 	  -  "--gzip"    -      "Compress the result with GZIP"
+	  -  "--no-comp" -      "Don't invoke compilation/linking step"
 ]
 
 ; mapping of commands used in the interactive input into command line arguments
@@ -198,6 +199,7 @@ nest-context: object [
 	no-eval?:     false
 	no-upx?:      false
 	clang?:       false
+	no-comp?:     false
 	run-result?:  false
 	update?:      false
 	gzip?:        false
@@ -309,6 +311,7 @@ do-args: closure/with [
 			find args "--help"    [ print banner print help-options-cli quit]
 			find args "--git-ssh" [ git-ssh?: on]
 			find args "--update"  [ git-update?: on]
+			find args "--no-comp" [ no-comp?: on]
 		]
 	]
 
@@ -833,6 +836,9 @@ parse-nest: closure/with [
 			return false
 		)
 	]]
+
+	; Disable compiler assignment when "--no-comp" option is used
+	if no-comp? [dest/compiler: none]
 
 	dest/files: unique dest/files
 	new-line/all dest/files true


### PR DESCRIPTION
The option allows to ignore the compilation/linking step for the .nest project altogether. 

This is important in situations when the whole build pass is not required, or the downstream uses some special and not immediately supported toolchain setup. Example: building Rebol itself, where Siskin is used for codegen phase only, but the compilation step is delegated to `zig build` setup.

The logic works by checking the input argument to see if the option has been defined, e.g `./siskin-linux-x86_64-static make/rebol3.nest --no-comp %rebol3-core-linux-x64`, and if it finds it, it sets the `compiler` value in the build spec to `none`, effectively preventing the compilation stage to proceed.